### PR TITLE
feat(ai): support existing code reading, interactive generation, and optional repo argument

### DIFF
--- a/src/ai/generator.rs
+++ b/src/ai/generator.rs
@@ -3,15 +3,35 @@ use std::path::Path;
 use std::io::Write;
 use crate::ai::providers::{LlmProvider, GeneratedFile};
 
-pub fn generate_plan(provider: &Box<dyn LlmProvider>, manifest_content: &str, service_name: &str) -> Result<String, String> {
+pub fn generate_plan(provider: &Box<dyn LlmProvider>, manifest_content: &str, service_name: &str, existing_code: &str, feedback: Option<&str>, previous_plan: Option<&str>) -> Result<String, String> {
+    let existing_code_section = if !existing_code.is_empty() {
+        format!(
+            "The directory already contains some code. You should refactor, update, or extend this existing code based on the instructions, rather than starting entirely from scratch unless requested.\n\n\
+            Existing Code:\n{}\n\n",
+            existing_code
+        )
+    } else {
+        String::new()
+    };
+
+    let feedback_section = match (feedback, previous_plan) {
+        (Some(f), Some(p)) => format!(
+            "The user reviewed your previous plan and provided the following feedback:\n{}\n\n\
+            Here was your previous plan:\n{}\n\n\
+            Please generate a NEW plan incorporating the user's feedback.\n\n",
+            f, p
+        ),
+        _ => String::new(),
+    };
+
     let prompt = format!(
         "You are FastGen AI, an expert software architect and Cloud Native engineer.\n\
-        The user wants to generate a microservice or infrastructure component named '{}'.\n\
+        The user wants to generate or update a microservice or infrastructure component named '{}'.\n\
         Read the following manifest/instructions:\n\n\
         {}\n\n\
-        Create a detailed step-by-step plan of the files and directories that will be created for this service.\n\
+        {}{}Create a detailed step-by-step plan of the files and directories that will be created or modified for this service.\n\
         Do NOT generate the code yet. Just describe the architecture and the file structure in Markdown.",
-        service_name, manifest_content
+        service_name, manifest_content, existing_code_section, feedback_section
     );
 
     provider.chat(&prompt)
@@ -22,16 +42,27 @@ pub fn execute_plan(
     manifest_content: &str,
     service_name: &str,
     plan_text: &str,
+    existing_code: &str,
     target_dir: &Path
 ) -> Result<(), String> {
+    let existing_code_section = if !existing_code.is_empty() {
+        format!(
+            "The following code already exists in the project. You should output the full, updated code for these files or new files as required by the plan.\n\n\
+            Existing Code:\n{}\n\n",
+            existing_code
+        )
+    } else {
+        String::new()
+    };
+
     let prompt = format!(
         "You are FastGen AI, an expert Cloud Native engineer.\n\
-        You must generate the code for a service named '{}'.\n\
+        You must generate or update the code for a service named '{}'.\n\
         Here is the original manifest:\n{}\n\n\
         Here is the approved plan:\n{}\n\n\
-        You MUST use the function 'create_files' to generate the files. \
+        {}You MUST use the function 'create_files' to generate the files. \
         Ensure all code is functional, clean, and follows best practices.",
-        service_name, manifest_content, plan_text
+        service_name, manifest_content, plan_text, existing_code_section
     );
 
     let files = provider.generate_files(&prompt)?;
@@ -48,7 +79,7 @@ pub fn execute_plan(
         let mut f = fs::File::create(&file_path).map_err(|e| format!("Failed to create file: {}", e))?;
         f.write_all(file.content.as_bytes()).map_err(|e| format!("Failed to write to file: {}", e))?;
 
-        println!("✅ Created file: {:?}", file_path);
+        println!("✅ Arquivo criado/atualizado: {:?}", file_path);
     }
 
     Ok(())

--- a/src/ai/orchestrator.rs
+++ b/src/ai/orchestrator.rs
@@ -8,18 +8,18 @@ use std::io::{self, Write};
 pub fn run_ai_generation(path: &str, config: &Config) {
     let base_path = Path::new(path);
     if !base_path.exists() || !base_path.is_dir() {
-        eprintln!("❌ Error: Path '{}' does not exist or is not a directory.", path);
+        eprintln!("❌ Erro: O caminho '{}' não existe ou não é um diretório.", path);
         return;
     }
 
     let provider_res = get_provider(config);
     if let Err(e) = provider_res {
-        eprintln!("❌ Failed to initialize AI provider: {}", e);
+        eprintln!("❌ Falha ao inicializar o provedor de IA: {}", e);
         return;
     }
 
     let provider = provider_res.unwrap();
-    println!("🤖 Initializing FastGen AI Generator...");
+    println!("🤖 Inicializando o Gerador de IA FastGen...");
 
     // Find services and validation rules
     let mut services: Vec<PathBuf> = Vec::new();
@@ -53,29 +53,26 @@ pub fn run_ai_generation(path: &str, config: &Config) {
     }
 
     if services.is_empty() {
-        println!("⚠️ No service directories found in {}", path);
+        println!("⚠️ Nenhum diretório de serviço encontrado em '{}'.", path);
         return;
     }
 
     for service_dir in services {
         let service_name = service_dir.file_name().unwrap().to_string_lossy().into_owned();
-        println!("\n🔍 Inspecting service: {}", service_name);
+        println!("\n🔍 Inspecionando o serviço: {}", service_name);
 
         // Find manifest (.md or .yml)
         let mut manifest_content = String::new();
+        let mut manifest_path = None;
         if let Ok(entries) = fs::read_dir(&service_dir) {
             for entry in entries.flatten() {
                 let p = entry.path();
-                // A manifest file should not be named "README.md" (if we want to ignore standard readmes),
-                // but any .md or .yml file like instrucoes.md, regras.md or manifest.md will work.
                 if p.is_file() && p.extension().map(|e| e == "md" || e == "yml" || e == "yaml").unwrap_or(false) {
                     let file_name = p.file_name().unwrap_or_default().to_string_lossy().to_lowercase();
-                    // Optional: skip generic files if you want to enforce specific names,
-                    // but usually we just take the first `.md` file found.
-                    // Taking the first .md file we can read.
                     if let Ok(content) = fs::read_to_string(&p) {
-                        println!("📄 Using manifest file: {}", file_name);
+                        println!("📄 Utilizando manifesto: {}", file_name);
                         manifest_content = content;
+                        manifest_path = Some(p);
                         break;
                     }
                 }
@@ -83,65 +80,140 @@ pub fn run_ai_generation(path: &str, config: &Config) {
         }
 
         if manifest_content.is_empty() {
-            println!("⚠️ No manifest (.md or .yml) found in service '{}', skipping...", service_name);
+            println!("⚠️ Nenhum manifesto (.md ou .yml) encontrado no serviço '{}'. Ignorando...", service_name);
             continue;
         }
 
-        // 1. Plan
-        println!("🧠 Generating architecture plan for {}...", service_name);
-        match generate_plan(&provider, &manifest_content, &service_name) {
-            Ok(plan) => {
-                println!("\n====================================");
-                println!("📋 PLAN FOR: {}", service_name);
-                println!("====================================\n");
-                println!("{}", plan);
-                println!("\n====================================");
+        // Scan for existing code
+        let mut existing_code = String::new();
+        fn read_existing_code(dir: &Path, acc: &mut String, manifest_path: Option<&Path>) {
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let name = path.file_name().unwrap_or_default().to_string_lossy();
 
-                print!("Do you approve this plan? [Y/n]: ");
-                io::stdout().flush().unwrap();
-                let mut input = String::new();
-                io::stdin().read_line(&mut input).unwrap();
-                if input.trim().to_lowercase() == "n" {
-                    println!("⏭️ Skipping service '{}'.", service_name);
-                    continue;
-                }
+                    // Skip hidden files/directories (like .git, .env) and common build/dependency folders
+                    if name.starts_with('.') || name == "target" || name == "node_modules" || name == "build" || name == "dist" || name == "venv" {
+                        continue;
+                    }
 
-                // 2. Execute
-                println!("🛠️  Generating files for {}...", service_name);
-                if let Err(e) = execute_plan(&provider, &manifest_content, &service_name, &plan, &service_dir) {
-                    eprintln!("❌ Failed to generate files for {}: {}", service_name, e);
-                    continue;
-                }
-                println!("✅ Generation complete for {}.", service_name);
-
-                // 3. Validation
-                if let Some(rules) = &validation_rules {
-                    println!("\n🛡️ Running Validation Agent for {}...", service_name);
-                    match validate_code(&provider, &service_dir, rules) {
-                        Ok(report) => {
-                            println!("\n--- Validation Report ---\n");
-                            println!("{}", report);
-                            println!("\n-------------------------\n");
-
-                            print!("Do you approve the validation results? [Y/n]: ");
-                            io::stdout().flush().unwrap();
-                            let mut val_input = String::new();
-                            io::stdin().read_line(&mut val_input).unwrap();
-                            if val_input.trim().to_lowercase() == "n" {
-                                println!("⚠️ Service '{}' validation was rejected.", service_name);
-                                // Here we could add a loop to re-generate or fix, but for now we just warn.
-                            } else {
-                                println!("✅ Service '{}' successfully validated and finished.", service_name);
+                    if path.is_dir() {
+                        read_existing_code(&path, acc, manifest_path);
+                    } else if path.is_file() {
+                        // Skip the manifest file itself
+                        if let Some(mp) = manifest_path {
+                            if path == mp {
+                                continue;
                             }
-                        },
-                        Err(e) => eprintln!("❌ Validation failed: {}", e)
+                        }
+
+                        // Try reading text files, ignore binary/unreadable files
+                        if let Ok(content) = fs::read_to_string(&path) {
+                            acc.push_str(&format!("\n\n--- Arquivo Existente: {:?} ---\n\n{}", path, content));
+                        }
                     }
                 }
+            }
+        }
 
-            },
-            Err(e) => eprintln!("❌ Failed to generate plan: {}", e)
+        read_existing_code(&service_dir, &mut existing_code, manifest_path.as_deref());
+
+        if !existing_code.is_empty() {
+            println!("🧩 Código existente encontrado em '{}'. O plano irá considerar refatoração/atualização.", service_name);
+        } else {
+            println!("🌱 Nenhum código pré-existente encontrado em '{}'. O plano irá gerar do zero.", service_name);
+        }
+
+        // 1. Plan
+        println!("🧠 Gerando plano de arquitetura para {}...", service_name);
+
+        let mut current_plan = match generate_plan(&provider, &manifest_content, &service_name, &existing_code, None, None) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("❌ Failed to generate plan: {}", e);
+                continue;
+            }
+        };
+
+        let mut approved = false;
+
+        while !approved {
+            println!("\n====================================");
+            println!("📋 PLANO PARA O SERVIÇO: {}", service_name);
+            println!("====================================\n");
+            println!("{}", current_plan);
+            println!("\n====================================");
+
+            print!("Você aprova este plano? [Y/n/i] (i = interagir/feedback): ");
+            io::stdout().flush().unwrap();
+            let mut input = String::new();
+            io::stdin().read_line(&mut input).unwrap();
+            let input_trimmed = input.trim().to_lowercase();
+
+            if input_trimmed == "n" {
+                println!("⏭️  Pulando o serviço '{}'.", service_name);
+                break;
+            } else if input_trimmed == "i" {
+                print!("💬 Digite seu feedback ou recomendação de mudança: ");
+                io::stdout().flush().unwrap();
+                let mut feedback = String::new();
+                io::stdin().read_line(&mut feedback).unwrap();
+                let feedback_trimmed = feedback.trim();
+
+                if !feedback_trimmed.is_empty() {
+                    println!("🔄 Gerando novo plano com base no seu feedback...");
+                    match generate_plan(&provider, &manifest_content, &service_name, &existing_code, Some(feedback_trimmed), Some(&current_plan)) {
+                        Ok(new_plan) => {
+                            current_plan = new_plan;
+                        },
+                        Err(e) => {
+                            eprintln!("❌ Falha ao regenerar o plano: {}", e);
+                            println!("⚠️ Mantendo o plano anterior.");
+                        }
+                    }
+                } else {
+                    println!("⚠️ Nenhum feedback fornecido. O plano não foi alterado.");
+                }
+            } else {
+                approved = true;
+            }
+        }
+
+        if !approved {
+            continue;
+        }
+
+        // 2. Execute
+        println!("🛠️  Gerando arquivos para {}...", service_name);
+        if let Err(e) = execute_plan(&provider, &manifest_content, &service_name, &current_plan, &existing_code, &service_dir) {
+            eprintln!("❌ Falha ao gerar arquivos para {}: {}", service_name, e);
+            continue;
+        }
+        println!("✅ Geração concluída para o serviço '{}'.", service_name);
+
+        // 3. Validation
+        if let Some(rules) = &validation_rules {
+            println!("\n🛡️  Executando Agente de Validação para o serviço {}...", service_name);
+            match validate_code(&provider, &service_dir, rules) {
+                Ok(report) => {
+                    println!("\n--- Relatório de Validação ---\n");
+                    println!("{}", report);
+                    println!("\n------------------------------\n");
+
+                    print!("Você aprova os resultados da validação? [Y/n]: ");
+                    io::stdout().flush().unwrap();
+                    let mut val_input = String::new();
+                    io::stdin().read_line(&mut val_input).unwrap();
+                    if val_input.trim().to_lowercase() == "n" {
+                        println!("⚠️ Validação do serviço '{}' foi rejeitada.", service_name);
+                    } else {
+                        println!("✅ Serviço '{}' validado e finalizado com sucesso.", service_name);
+                    }
+                },
+                Err(e) => eprintln!("❌ Falha na validação: {}", e)
+            }
         }
     }
 
-    println!("\n🎉 All services processed successfully!");
+    println!("\n🎉 Todos os serviços foram processados com sucesso!");
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,13 +45,18 @@ enum Commands {
         #[arg(long)]
         to: String,
     },
+    /// Inicia o Dev UI do FastGen
     DevUi {
-        #[arg(long)]
+        /// Caminho para o repositório/workspace contendo o docker-compose.yml. Padrão é o diretório atual.
+        #[arg(long, default_value = ".")]
         repo: String,
+        /// Caminho para a pasta contendo os manifestos de IA
         #[arg(long)]
         ai_path: Option<String>,
     },
+    /// Inicia a geração de código via IA a partir de manifestos
     AiGenerate {
+        /// Caminho para a pasta contendo os manifestos de IA
         #[arg(short, long)]
         path: String,
     },

--- a/src/workspace/devui.rs
+++ b/src/workspace/devui.rs
@@ -78,7 +78,7 @@ fn handle_post_plan(request: &mut tiny_http::Request, config: &Config, ai_path: 
     }
 
     let parsed: Result<JsonValue, _> = serde_json::from_str(&content);
-    let service_name = match parsed {
+    let service_name = match &parsed {
         Ok(v) => v["service"].as_str().unwrap_or("").to_string(),
         Err(_) => return json!({"error": "Invalid JSON"}).to_string(),
     };
@@ -115,8 +115,47 @@ fn handle_post_plan(request: &mut tiny_http::Request, config: &Config, ai_path: 
         return json!({"error": "No manifest found"}).to_string();
     }
 
-    match generate_plan(&provider, &manifest_content, &service_name) {
-        Ok(plan) => json!({"plan": plan, "manifest": manifest_content}).to_string(),
+    // Scan for existing code
+    let mut existing_code = String::new();
+    fn read_existing_code(dir: &Path, acc: &mut String) {
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let name = path.file_name().unwrap_or_default().to_string_lossy();
+
+                // Skip hidden files/directories (like .git, .env) and common build/dependency folders
+                if name.starts_with('.') || name == "target" || name == "node_modules" || name == "build" || name == "dist" || name == "venv" {
+                    continue;
+                }
+
+                if path.is_dir() {
+                    read_existing_code(&path, acc);
+                } else if path.is_file() {
+                    let ext = path.extension().unwrap_or_default().to_string_lossy();
+                    if ext != "md" && ext != "yml" && ext != "yaml" {
+                        if let Ok(content) = fs::read_to_string(&path) {
+                            acc.push_str(&format!("\n\n--- Existing File: {:?} ---\n\n{}", path, content));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    read_existing_code(&service_dir, &mut existing_code);
+
+    // Extract feedback and previous plan if they exist (for interactive generation from UI in the future)
+    let feedback = match &parsed {
+        Ok(v) => v.get("feedback").and_then(|f| f.as_str()).map(|s| s.to_string()),
+        Err(_) => None,
+    };
+    let previous_plan = match &parsed {
+        Ok(v) => v.get("previous_plan").and_then(|p| p.as_str()).map(|s| s.to_string()),
+        Err(_) => None,
+    };
+
+    match generate_plan(&provider, &manifest_content, &service_name, &existing_code, feedback.as_deref(), previous_plan.as_deref()) {
+        Ok(plan) => json!({"plan": plan, "manifest": manifest_content, "existing_code": existing_code}).to_string(),
         Err(e) => json!({"error": format!("Plan generation failed: {}", e)}).to_string(),
     }
 }
@@ -128,11 +167,12 @@ fn handle_post_execute(request: &mut tiny_http::Request, config: &Config, ai_pat
     }
 
     let parsed: Result<JsonValue, _> = serde_json::from_str(&content);
-    let (service_name, plan, manifest) = match parsed {
+    let (service_name, plan, manifest, existing_code) = match parsed {
         Ok(v) => (
             v["service"].as_str().unwrap_or("").to_string(),
             v["plan"].as_str().unwrap_or("").to_string(),
             v["manifest"].as_str().unwrap_or("").to_string(),
+            v["existing_code"].as_str().unwrap_or("").to_string(),
         ),
         Err(_) => return json!({"error": "Invalid JSON"}).to_string(),
     };
@@ -152,7 +192,7 @@ fn handle_post_execute(request: &mut tiny_http::Request, config: &Config, ai_pat
 
     let service_dir = Path::new(path).join(&service_name);
 
-    if let Err(e) = execute_plan(&provider, &manifest, &service_name, &plan, &service_dir) {
+    if let Err(e) = execute_plan(&provider, &manifest, &service_name, &plan, &existing_code, &service_dir) {
         return json!({"error": format!("Execution failed: {}", e)}).to_string();
     }
 
@@ -310,6 +350,7 @@ fn generate_html(repo: &str, ai_path: Option<&str>) -> String {
         let currentService = "";
         let currentPlan = "";
         let currentManifest = "";
+        let currentExistingCode = "";
 
         function switchTab(tabId) {{
             document.querySelectorAll('.tab-content').forEach(el => el.classList.add('hidden'));
@@ -343,6 +384,7 @@ fn generate_html(repo: &str, ai_path: Option<&str>) -> String {
             currentService = name;
             currentPlan = "";
             currentManifest = "";
+            currentExistingCode = "";
 
             document.getElementById('ai-welcome').classList.add('hidden');
             document.getElementById('ai-service-panel').classList.remove('hidden');
@@ -388,6 +430,7 @@ fn generate_html(repo: &str, ai_path: Option<&str>) -> String {
                 }} else {{
                     currentPlan = data.plan;
                     currentManifest = data.manifest;
+                    currentExistingCode = data.existing_code;
 
                     document.getElementById('plan-content').innerHTML = marked.parse(currentPlan);
                     document.getElementById('plan-container').classList.remove('hidden');
@@ -411,7 +454,8 @@ fn generate_html(repo: &str, ai_path: Option<&str>) -> String {
                     body: JSON.stringify({{
                         service: currentService,
                         plan: currentPlan,
-                        manifest: currentManifest
+                        manifest: currentManifest,
+                        existing_code: currentExistingCode
                     }})
                 }});
                 const data = await res.json();

--- a/teste/services/produto/manifest.md
+++ b/teste/services/produto/manifest.md
@@ -1,0 +1,1 @@
+Make a python product microservice using FastAPI


### PR DESCRIPTION
Implemented the ability to read existing files and refactor them, added an interactive mode for AI generation, improved terminal logs with elegant Portuguese translations, and made `--repo` optional in the Dev UI CLI.

---
*PR created automatically by Jules for task [10802319313930158040](https://jules.google.com/task/10802319313930158040) started by @gomesrocha*