### PR TITLE
🔒 fix: handle errors gracefully in add_external_service

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,7 +69,12 @@ pub fn run(config: Config) {
         Commands::Plugin { name, project } => apply_plugin(&name, &project, &config),
         Commands::NewWorkspace { name } => create_workspace(&name),
         Commands::AddService { name, to, ai } => add_service(&name, &to, ai),
-        Commands::AddExt { name, to } => add_external_service(&name, &to),
+        Commands::AddExt { name, to } => {
+            if let Err(e) = add_external_service(&name, &to) {
+                eprintln!("{}", e);
+                std::process::exit(1);
+            }
+        }
         Commands::DevUi { repo, ai_path } => start_dev_ui(&repo, ai_path.as_deref(), &config),
         Commands::AiGenerate { path } => run_ai_generation(&path, &config),
     }

--- a/src/workspace/external.rs
+++ b/src/workspace/external.rs
@@ -1,25 +1,31 @@
 use std::path::Path;
+use std::error::Error;
 
-pub fn add_external_service(name: &str, repo: &str) {
+pub fn add_external_service(name: &str, repo: &str) -> Result<(), Box<dyn Error>> {
     let template_path = format!("templates/external/{}.yml", name);
     let snippet = std::fs::read_to_string(&template_path)
-        .unwrap_or_else(|_| panic!("Serviço externo '{}' não encontrado.", name));
+        .map_err(|_| format!("Serviço externo '{}' não encontrado.", name))?;
 
     let compose_path = Path::new(repo).join("docker-compose.yml");
-    let mut compose = std::fs::read_to_string(&compose_path).unwrap();
+    let mut compose = std::fs::read_to_string(&compose_path)
+        .map_err(|e| format!("Erro ao ler docker-compose.yml em '{}': {}", repo, e))?;
 
     if !compose.contains(&format!("  {}:", name)) {
         compose.push_str(&format!("\n{}", snippet));
-        std::fs::write(&compose_path, compose).unwrap();
+        std::fs::write(&compose_path, compose)
+            .map_err(|e| format!("Erro ao salvar docker-compose.yml: {}", e))?;
     }
 
     let env_path = Path::new(repo).join(".env");
-    let mut env = std::fs::read_to_string(&env_path).unwrap();
+    let mut env = std::fs::read_to_string(&env_path)
+        .map_err(|e| format!("Erro ao ler .env em '{}': {}", repo, e))?;
+
     if !env.contains(&format!("{}_ENABLED=true", name.to_uppercase())) {
         env.push_str(&format!("{}_ENABLED=true\n", name.to_uppercase()));
-        std::fs::write(&env_path, env).unwrap();
+        std::fs::write(&env_path, env)
+            .map_err(|e| format!("Erro ao salvar .env: {}", e))?;
     }
 
     println!("Serviço externo '{}' adicionado ao docker-compose.", name);
+    Ok(())
 }
-


### PR DESCRIPTION
- Refactored `add_external_service` in `src/workspace/external.rs` to return `Result<(), Box<dyn Error>>`.
- Replaced unsafe `unwrap()` and `panic!` calls with error propagation using the `?` operator and descriptive error messages in Portuguese.
- Updated `src/cli.rs` to handle the `Result` and exit with code 1 on error.
- Verified the fix with a reproduction script.

# 📦 Pull Request

## ✨ Descrição
Descreva brevemente o que foi feito neste PR:

- [ ] Nova funcionalidade
- [ ] Correção de bug
- [ ] Refatoração
- [ ] Documentação
- [ ] Outros (especifique)

## 🔗 Issue relacionada
Closes #<número da issue>

## 📄 Alterações
- Item 1
- Item 2
- Item 3
(Exemplos)
- Criado módulo `qdrant.rs` com funções de inserção e consulta de vetores
- Adicionada dependência da API do QDrant via HTTP
- Criado serviço para abstração da comunicação com o QDrant

## 🧪 Testes
- [ ] Testado localmente
- [ ] Inclui novos testes
- [ ] Testes existentes passaram

## 📝 Observações
Inclua qualquer detalhe adicional, dúvidas ou limitações.